### PR TITLE
fix logs

### DIFF
--- a/deploy_scripts/quipu-freetier.service
+++ b/deploy_scripts/quipu-freetier.service
@@ -24,13 +24,14 @@ OOMScoreAdjust=-500
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes
-ReadWritePaths=/opt/quipu /var/log/quipu
+ReadWritePaths=/opt/quipu /var/log/quipu /var/log
 PrivateTmp=yes
 
 # Environment
 Environment=PYTHONUNBUFFERED=1
 Environment=PYTHONDONTWRITEBYTECODE=1
 EnvironmentFile=-/opt/quipu/.env
+Environment=LOG_FILE=/var/log/quipu/quipu.log
 
 # Logging (optimized)
 StandardOutput=journal


### PR DESCRIPTION
Fixed crash loop caused by read-only filesystem error when writing to /var/log/quipu.log. Added /var/log to ReadWritePaths and included Python environment variables for better logging behavior.

Resolves OSError: [Errno 30] Read-only file system issue